### PR TITLE
Measuring true metrics for original model

### DIFF
--- a/model_build.ipynb
+++ b/model_build.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -258,7 +258,7 @@
        "max     75.000000   19.000000   19.000000   20.000000  "
       ]
      },
-     "execution_count": 2,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -269,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -304,7 +304,7 @@
        "[395 rows x 33 columns]>"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -322,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -354,7 +354,7 @@
        "[395 rows x 4 columns]>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -373,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +382,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -494,7 +494,7 @@
        "max     22.000000    5.000000   75.000000   20.000000      1.000000"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -512,12 +512,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
     "include = ['health', 'absences','age','qual_student']\n",
     "df.drop(columns=df.columns.difference(include), inplace=True) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split\n",
+    "dependent_variable = 'qual_student'\n",
+    "x = df[df.columns.difference([dependent_variable])]\n",
+    "y = df[dependent_variable]\n",
+    "x_train, x_test, y_train, y_test = train_test_split(x, y, test_size=0.3)"
    ]
   },
   {
@@ -529,7 +542,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
@@ -538,7 +551,7 @@
        "RandomForestClassifier(n_estimators=1000)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -546,32 +559,32 @@
    "source": [
     "from sklearn.ensemble import RandomForestClassifier as rf\n",
     "import sklearn\n",
-    "dependent_variable = 'qual_student'\n",
-    "x = df[df.columns.difference([dependent_variable])]\n",
-    "y = df[dependent_variable]\n",
     "clf = rf(n_estimators = 1000)\n",
-    "clf.fit(x, y)"
+    "clf.fit(x_train, y_train)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.5185185185185185"
+       "0.773109243697479"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pred = clf.predict(x)\n",
-    "sklearn.metrics.f1_score(y, pred, average='binary')"
+    "pred = clf.predict(x_test)\n",
+    "print(sklearn.metrics.f1_score(y_test, pred, average='binary'))\n",
+    "print(sklearn.metrics.precision_score(y_test, pred, average='binary'))\n",
+    "print(sklearn.metrics.recall_score(y_test, pred, average='binary'))\n",
+    "print(sklearn.metrics.accuracy_score(y_test, pred))"
    ]
   },
   {
@@ -584,18 +597,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "['/home/matrix/dockerfile/apps/model.pkl']"
-      ]
-     },
-     "execution_count": 54,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'home/matrix/dockerfile/apps/model.pkl'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[1;32m~\\AppData\\Local\\Temp/ipykernel_20548/2273806169.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;32mimport\u001b[0m \u001b[0mjoblib\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      2\u001b[0m \u001b[1;31m# modify the file path to where you want to save the model\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 3\u001b[1;33m \u001b[0mjoblib\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdump\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mclf\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'home/matrix/dockerfile/apps/model.pkl'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[1;32m~\\AppData\\Local\\Programs\\Python\\Python39\\lib\\site-packages\\joblib\\numpy_pickle.py\u001b[0m in \u001b[0;36mdump\u001b[1;34m(value, filename, compress, protocol, cache_size)\u001b[0m\n\u001b[0;32m    477\u001b[0m             \u001b[0mNumpyPickler\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mf\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mprotocol\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mprotocol\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdump\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    478\u001b[0m     \u001b[1;32melif\u001b[0m \u001b[0mis_filename\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 479\u001b[1;33m         \u001b[1;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;34m'wb'\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mas\u001b[0m \u001b[0mf\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    480\u001b[0m             \u001b[0mNumpyPickler\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mf\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mprotocol\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mprotocol\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdump\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    481\u001b[0m     \u001b[1;32melse\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'home/matrix/dockerfile/apps/model.pkl'"
+     ]
     }
    ],
    "source": [
@@ -606,7 +621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,7 +630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -753,7 +768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -774,15 +789,23 @@
  ],
  "metadata": {
   "interpreter": {
-   "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   "hash": "a344410e80b6f5b7999a1ec2deb257bd2f09b841cbfbf5d97efe82c599e6bd66"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 64-bit",
+   "display_name": "Python 3.9.0 64-bit",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": ""
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Split data into training and testing sets (30% set aside for testing) to get a better sense of the original model's performance. The original model was reporting an F1 score of 0.519 but this metric was misleading since the testing was done on the training data which is not how models should be tested since it will be overfit to the entire input dataset and naturally appear to perform well in tests that are from the input. The true metrics found via proper testing are below:

F1- 0.07407407407407407
Precision- 0.2
Recall- 0.045454545454545456
Accuracy- 0.7899159663865546

This is labeled as wontfix since we're not going to be working on the original model any further and this PR is going to be closed without merge. The primary point of this PR is to document the metrics above so we can benchmark our improved model against them.