### PR TITLE
Query params validation

### DIFF
--- a/dockerfile/apps/app.py
+++ b/dockerfile/apps/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, abort
 import joblib
 import pandas as pd
 import numpy as np
@@ -9,6 +9,9 @@ app = Flask(__name__)
 def hello():
     return "try the predict route it is great!"
 
+def roundtrip_typchecks(param):
+    return str(int(param)) == param
+
 @app.route('/predict')
 def predict():
 	 #use entries from the query string here but could also use json
@@ -17,6 +20,27 @@ def predict():
      schoolsup = request.args.get('schoolsup')
      d_alc = request.args.get('Dalc')
      w_alc = request.args.get('Walc')
+
+     # typecheck and validate ranges
+     if not (roundtrip_typchecks(m_edu) and roundtrip_typchecks(failures) and roundtrip_typchecks(schoolsup) 
+        and roundtrip_typchecks(d_alc) and roundtrip_typchecks(w_alc)):
+        abort(400)
+
+     if not (0 <= int(m_edu) <= 4):
+        abort(400)
+
+     if not (0 <= int(failures) <= 4):
+        abort(400)
+
+     if not (int(schoolsup) == 0 or int(schoolsup) == 1):
+        abort(400)
+
+     if not (1 <= int(d_alc) <= 5):
+        abort(400)
+
+     if not (1 <= int(w_alc) <= 5):
+        abort(400)
+
      query_df = pd.DataFrame({ 'Medu' : pd.Series(m_edu) ,'failures' : pd.Series(failures) ,'schoolsup' : pd.Series(schoolsup) , 'Dalc' : pd.Series(d_alc) , 'Walc' : pd.Series(w_alc) })
      query = pd.get_dummies(query_df)
      prediction = clf.predict(query)

--- a/dockerfile/apps/app.py
+++ b/dockerfile/apps/app.py
@@ -10,7 +10,12 @@ def hello():
     return "try the predict route it is great!"
 
 def roundtrip_typchecks(param):
-    return str(int(param)) == param
+    param_int = None
+    try:
+        param_int = int(param)
+    except:
+        return False
+    return str(param_int) == param
 
 @app.route('/predict')
 def predict():


### PR DESCRIPTION
Resolves #5

This PR updates the API call to now require that the following fields provided in the query are all integers AND that they fall within the ranges described below. 

`Medu` - mother's education (0 - none,  1 - primary education (4th grade), 2 – 5th to 9th grade, 3 – secondary education or 4 – higher education)
`failures` - number of past class failures (n if 1<=n<3, else 4)
`schoolsup` - extra educational support (1 - yes, 0 - no)
`Dalc` - workday alcohol consumption (from 1 - very low to 5 - very high)
`Walc` - weekend alcohol consumption (from 1 - very low to 5 - very high)

It has been manually tested on various queries and will have accompanying automated tests soon.